### PR TITLE
Add filter by chip functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "d3": "^7.9.0",
+        "mitt": "^3.0.1",
         "vue": "^3.5.12",
         "vue-router": "^4.4.5",
         "vuetify": "^3.7.4"
@@ -3172,6 +3173,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@mdi/font": "^7.4.47",
     "d3": "^7.9.0",
+    "mitt": "^3.0.1",
     "vue": "^3.5.12",
     "vue-router": "^4.4.5",
     "vuetify": "^3.7.4"

--- a/src/components/ChipList.vue
+++ b/src/components/ChipList.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
 import { VChip } from 'vuetify/components'
+import { eventBus } from '../utils/event-bus'
+
+const handleChipClicked = (tag: string) => {
+  eventBus.emit('tagClicked', tag)
+}
+
 interface ChipListProps {
   itemList: string
   variant?: VChip['variant']
@@ -10,9 +16,13 @@ const displayList = props.itemList.split(', ')
 
 <template>
   <div class="chipList">
-    <v-chip v-for="item in displayList" :key="item" :variant="variant">{{
-      item
-    }}</v-chip>
+    <v-chip
+      v-for="item in displayList"
+      :key="item"
+      :variant="variant"
+      @click="handleChipClicked(item)"
+      >{{ item }}</v-chip
+    >
   </div>
 </template>
 

--- a/src/components/ChipList.vue
+++ b/src/components/ChipList.vue
@@ -16,7 +16,7 @@ const displayList = props.itemList.split(', ')
 </script>
 
 <template>
-  <v-chip-group selected-class="">
+  <v-chip-group selected-class="" :column="true">
     <v-chip
       v-for="item in displayList"
       :key="item"

--- a/src/components/ChipList.vue
+++ b/src/components/ChipList.vue
@@ -7,6 +7,7 @@ const handleChipClicked = (tag: string) => {
 }
 
 interface ChipListProps {
+  filter: string
   itemList: string
   variant?: VChip['variant']
 }
@@ -15,19 +16,19 @@ const displayList = props.itemList.split(', ')
 </script>
 
 <template>
-  <div class="chipList">
+  <v-chip-group selected-class="">
     <v-chip
       v-for="item in displayList"
       :key="item"
-      :variant="variant"
+      :variant="item == filter ? 'elevated' : variant"
       @click="handleChipClicked(item)"
       >{{ item }}</v-chip
     >
-  </div>
+  </v-chip-group>
 </template>
 
 <style lang="css" scoped>
-.chipList {
-  padding-bottom: 0.5rem;
+.v-chip--selected {
+  background-color: purple;
 }
 </style>

--- a/src/components/DreamsList.vue
+++ b/src/components/DreamsList.vue
@@ -15,8 +15,12 @@ const dreamsList = reactive(dreams)
 const filter = ref('')
 
 const handleChipClicked = (tag: string) => {
-  filter.value = tag
-  handleUpdateFilter(tag)
+  if (filter.value == tag) {
+    filter.value = ''
+  } else {
+    filter.value = tag
+  }
+  handleUpdateFilter(filter.value)
 }
 
 function handleUpdateFilter(newValue: string) {
@@ -50,7 +54,7 @@ const filteredDreams = computed(() => {
       v-for="dream in filteredDreams"
       :key="dream.date"
       :dream="dream"
-      :chip-clicked="handleChipClicked"
+      :filter="filter"
     />
   </v-list>
 </template>

--- a/src/components/DreamsList.vue
+++ b/src/components/DreamsList.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { ref, reactive, computed } from 'vue'
+import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
 import { normalize } from '../data/utils'
+import { eventBus } from '../utils/event-bus'
+
+onMounted(() => eventBus.on('tagClicked', handleChipClicked))
+onUnmounted(() => eventBus.off('tagClicked', handleChipClicked))
 
 import dreams from '../data/data.json'
 import DreamsListItem from './DreamsListItem.vue'
@@ -9,6 +13,11 @@ import FilterBar from './FilterBar.vue'
 const dreamsList = reactive(dreams)
 
 const filter = ref('')
+
+const handleChipClicked = (tag: string) => {
+  filter.value = tag
+  handleUpdateFilter(tag)
+}
 
 function handleUpdateFilter(newValue: string) {
   filter.value = newValue
@@ -41,6 +50,7 @@ const filteredDreams = computed(() => {
       v-for="dream in filteredDreams"
       :key="dream.date"
       :dream="dream"
+      :chip-clicked="handleChipClicked"
     />
   </v-list>
 </template>

--- a/src/components/DreamsList.vue
+++ b/src/components/DreamsList.vue
@@ -18,10 +18,12 @@ const filteredDreams = computed(() => {
   return dreamsList.filter((dream) => {
     const noramlizedDescription = normalize(dream.description)
     const noramlizedTags = normalize(dream.tags)
+    const normalizedCircumstances = normalize(dream.circumstances)
     const normalizedFilter = normalize(filter.value)
     return (
       noramlizedDescription.includes(normalizedFilter) ||
-      noramlizedTags.includes(normalizedFilter)
+      noramlizedTags.includes(normalizedFilter) ||
+      normalizedCircumstances.includes(normalizedFilter)
     )
   })
 })

--- a/src/components/DreamsListItem.vue
+++ b/src/components/DreamsListItem.vue
@@ -2,7 +2,7 @@
 import ChipList from './ChipList.vue'
 import { Dream } from './types/types'
 
-const props = defineProps<{ dream: Dream }>()
+const props = defineProps<{ dream: Dream; filter: string }>()
 
 const formattedDate = new Date(props.dream.date).toDateString()
 const firstLetter = props.dream.description.charAt(0).toUpperCase()
@@ -14,10 +14,11 @@ const formattedDescription = firstLetter + restOfDesc + '.'
   <v-list-item class="dream">
     <h2 class="dream-heading">{{ formattedDate }}</h2>
     <p>{{ formattedDescription }}</p>
-    <ChipList :item-list="dream.tags" />
+    <ChipList :item-list="dream.tags" :filter="filter" />
     <ChipList
       v-if="dream.circumstances.length"
       :item-list="dream.circumstances"
+      :filter="filter"
       variant="text"
     />
     <v-divider />

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue'
 interface FilterBarProps {
   filter: string
   itemName: string
 }
 const props = defineProps<FilterBarProps>()
-const localFilter = props.filter
+const localFilter = ref(props.filter)
+
+watch(
+  () => props.filter,
+  (newValue: string) => {
+    localFilter.value = newValue
+  }
+)
 </script>
 
 <template>

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -20,7 +20,6 @@ watch(
     :label="`filter ${itemName}s`"
     class="filter-bar"
     v-model="localFilter"
-    append-icon="mdi-close"
     prepend-icon="mdi-magnify"
     @input="$emit('update-filter', localFilter)"
   >

--- a/src/components/TagsList.vue
+++ b/src/components/TagsList.vue
@@ -3,11 +3,12 @@ import { ref, reactive, computed } from 'vue'
 import dreams from '../data/data.json'
 import { normalize } from '../data/utils'
 import FilterBar from './FilterBar.vue'
+import { Dream } from './types/types'
 
-const tags = reactive([])
+const tags = reactive<Array<string>>([])
 const filter = ref('')
 
-dreams.forEach((dream) => {
+dreams.forEach((dream: Dream) => {
   const dreamTags = dream.tags.split(', ')
   dreamTags.forEach((tag) => {
     const normalizedTag = normalize(tag)

--- a/src/data/data.json
+++ b/src/data/data.json
@@ -69,7 +69,7 @@
     "date": "2024-11-07",
     "description": "protesting in the streets when Trump tries to keep power after his term. Taking Daisy to doggy preschool with Sarah",
     "tags": "friend, politics, daisy, school, shopping, crusade, danger, dog, fight, rebellion",
-    "circumstances": "horny"
+    "circumstances": ""
   },
   {
     "date": "2024-11-05",
@@ -87,7 +87,7 @@
     "date": "2024-10-25",
     "description": "Mom, Zack and I attend Au. meetup. Library on magic turtle; vortex lake. Hunger games fight with bows and berries",
     "tags": "adventure, fight, family, friend, creatures, danger, infiltrate, earworm, magic, space",
-    "circumstances": "horny"
+    "circumstances": ""
   },
   {
     "date": "2024-10-23",
@@ -159,7 +159,7 @@
     "date": "2024-10-09",
     "description": "family reunion at gorgeous Italian compound. Befriend eagle; feed it treats. Miss Grandma. Cousins get rowdy",
     "tags": "italy, family-reunion, family, grandma-Day, animal-friend, hide, bittersweet, longing",
-    "circumstances": "horny"
+    "circumstances": ""
   },
   {
     "date": "2024-10-08",
@@ -171,7 +171,7 @@
     "date": "2024-10-07",
     "description": "going back to high school. Cousin Sam is admin. Nail salon for Lindsay's wedding. Summer travels with family. Talk to Dad about drinking",
     "tags": "family, sad, bad-driving, highschool, planning, upcoming-event, lost-item",
-    "circumstances": "stress, horny"
+    "circumstances": "stress, "
   },
   {
     "date": "2024-10-06",
@@ -201,7 +201,7 @@
     "date": "2024-10-02",
     "description": "Train hijinks, trying to stop some bad guy something something (wrote this down too late, haha)",
     "tags": "family, train, adventure, infiltrate",
-    "circumstances": "horny"
+    "circumstances": ""
   },
   {
     "date": "2024-10-01",

--- a/src/data/tag-groups.json
+++ b/src/data/tag-groups.json
@@ -37,11 +37,11 @@
     "tense"
   ],
   "media": ["movie", "personify-character", "sci-fi"],
-  "clothes": ["fashion", "dressing"],
+  "fashion": ["fashion", "dressing", "decorating"],
   "fun": ["fun", "party", "dance", "surprise", "win", "drugs"],
   "perfoming": ["performance", "costumes", "actors", "celebrity"],
   "negative": ["late", "mess", "divorce"],
-  "stealth": ["sneak", "hiding", "hide", "spy", "spying"],
+  "stealth": ["sneak", "hiding", "hide", "spy", "spying", "infiltrate"],
   "danger": [
     "danger",
     "escape",
@@ -49,7 +49,6 @@
     "horror",
     "violence",
     "conflict",
-    "infiltrate",
     "dark",
     "unease",
     "poison",
@@ -68,20 +67,12 @@
     "christmas",
     "family-reunion"
   ],
-  "resources": ["money", "delivery"],
+  "resources": ["money", "delivery", "shopping"],
   "food": ["food", "candy", "cooking"],
   "antagonists": ["bullies", "Asshole", "demons", "monster"],
-  "planning": [
-    "planning",
-    "shopping",
-    "packing",
-    "getting-ready",
-    "cleaning",
-    "decorating",
-    "fixing"
-  ],
+  "planning": ["planning", "packing", "getting-ready", "cleaning", "fixing"],
   "searching": ["lost-item", "search"],
-  "loved-ones": ["friend-cameo", "family-cameo", "daisy", "grandma-day"],
+  "loved-ones": ["friend", "family", "daisy", "grandma-day"],
   "animals": [
     "animals",
     "animal-friend",
@@ -101,8 +92,8 @@
     "teaching",
     "math",
     "working",
-    "classmate-cameo",
-    "coworker-cameo"
+    "classmate",
+    "coworker"
   ],
   "fitness": [
     "soccer",

--- a/src/utils/event-bus.ts
+++ b/src/utils/event-bus.ts
@@ -1,5 +1,7 @@
 import mitt from 'mitt'
-type EventBus = {
+
+type EventBusEvents = {
   tagClicked: string
 }
-export const eventBus = mitt<EventBus>()
+
+export const eventBus = mitt<EventBusEvents>()

--- a/src/utils/event-bus.ts
+++ b/src/utils/event-bus.ts
@@ -1,0 +1,5 @@
+import mitt from 'mitt'
+type EventBus = {
+  tagClicked: string
+}
+export const eventBus = mitt<EventBus>()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
+    "strict": true,
     "types": ["node", "vuetify"],
     "allowJs": true,
     "esModuleInterop": true,


### PR DESCRIPTION
# What was changed

- Installed [mitt](https://www.npmjs.com/package/mitt) to handle events traveling more than one level up the component hierarchy
- made chips clickable
    - In the dream list, when clicked, the chip's tag string becomes the list's filter
    - All related chips are highlighted
    
## Things to note
- There is a minor workaround in use
    - `v-chip-list` records which v-chip is selected, but since our app handles selection separately, I just set the selected class to `''` so previously selected chips don't render differently. 
    - There may be UX or a11y repercussions that need to be fixed later

## Screenshots

### Before

https://github.com/user-attachments/assets/d5533a8b-ac5b-4e3d-a88e-eeca0b19351e

### After

https://github.com/user-attachments/assets/d0d0f15f-b117-429f-baea-01198c34160c